### PR TITLE
Stick to exact pysaml version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'pysaml2>=4.0.5',
+        'pysaml2==4.0.5',
         'python-memcached>=1.48',
         ],
     )


### PR DESCRIPTION
"""We actually have some unresolved issues with pysaml2 compatibility,
so I prefer sticking with the exact version which is currently
considered the best.""" --Jozef
